### PR TITLE
Create the GitHub release from the workflow, not by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,48 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+
+  github-release:
+    name: create the GitHub release
+    # Runs only after PyPI accepted the upload, so a GitHub release never claims a version that was
+    # not actually published.
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: extract this version's changelog section
+        run: |
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          version = tag.removeprefix("v")
+          changelog = pathlib.Path("CHANGELOG.md").read_text()
+          # everything from this version's heading up to the next one
+          match = re.search(
+              rf"^## \[{re.escape(version)}\].*?\n(.*?)(?=^## \[)",
+              changelog,
+              re.MULTILINE | re.DOTALL,
+          )
+          notes = match.group(1).strip() if match else f"See CHANGELOG.md for {version}."
+          pathlib.Path("release-notes.md").write_text(notes + "\n")
+          print(f"extracted {len(notes.splitlines())} lines of notes for {version}")
+          PY
+      # gh is preinstalled on GitHub runners, so this needs no third-party action.
+      - name: create the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release create "${{ github.ref_name }}"
+          --title "${{ github.ref_name }}"
+          --notes-file release-notes.md
+          --verify-tag
+          dist/*


### PR DESCRIPTION
`release.yml` built and published the distribution but never created a GitHub release. v0.3.0 landed
on PyPI with a bare tag and no release entry.

v0.2.0 *has* a release only because I created it manually during that release, which is exactly why
the gap stayed invisible until the second release actually used the workflow. Fixing only the missing
v0.3.0 release would have hidden it again until 0.4.0.

## What this adds

A `github-release` job that extracts the version's section from `CHANGELOG.md`, creates the release,
and attaches the built wheel and sdist as assets.

## Two deliberate choices

**It `needs: publish`.** A GitHub release can never claim a version PyPI did not accept. If the
publish is rejected, or you decline the environment approval, no release is left behind.

**It uses `gh`, not a third-party action.** `gh` is preinstalled on GitHub runners, so this needs no
supply-chain surface and no SHA to keep pinned for what is one command. `softprops/action-gh-release`
would have worked and is well maintained, but it is not worth a dependency here.

`contents: write` is scoped to this job alone; `publish` keeps only `id-token: write`.

## Verification

```
yaml parses            jobs: build, publish, github-release
notes extraction       0.3.0 -> 90 lines, 0.2.0 -> 63 lines, against the real CHANGELOG
ruff                   All checks passed
```

The v0.3.0 release has been created by hand in the meantime, so the history is not left with a gap.
This makes 0.4.0 onwards automatic.

Also the first change to go through the branch protection applied today.