### PR TITLE
refactor: make numpy the only runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Removed
+
+- **pandas and scikit-learn are no longer required.** `numpy` is the only runtime dependency.
+  Measured on Linux/CPython 3.12, a fresh install drops from **333 MB across 10 packages to 69 MB
+  across 1** — a 264 MB reduction, 79% of the payload, since the two also pulled in scipy, joblib,
+  narwhals, python-dateutil, six and threadpoolctl.
+
+  Nothing is lost, and input support is *wider*. pandas was used for one `isinstance` check before
+  calling `.to_numpy()`; `np.asarray` already does that via the `__array__` protocol. Because
+  that is a protocol rather than a library, polars, pyarrow, xarray and CuPy objects now work too,
+  without this package knowing they exist.
+
+  scikit-learn supplied one PCA and one z-score, now about twenty lines of `np.linalg.svd`. Both
+  libraries remain in the `dev` extra, where `tests/test_linalg_matches_sklearn.py` re-derives every
+  fit both ways on every CI run rather than trusting a one-off measurement. `pip install
+  python-som[examples]` restores the previous install set for anyone relying on it.
+
+  If you imported pandas or scikit-learn *transitively* through this package, add them to your own
+  dependencies. That reliance was always an accident of packaging.
+
+### Fixed
+
+- **Linear initialization was inaccurate for data far from the origin.** Through 0.3.0 its PCA went
+  to scikit-learn's `auto` solver, which since 1.5 selects `covariance_eigh` when samples outnumber
+  features — it forms the covariance matrix, and squaring the data squares its condition number. On
+  `(150, 4)` data offset by 1e7, the second explained variance was wrong by **5.8%**, and the
+  resulting models differed from the correct ones by 2.43 against a total model spread of 2.0: an
+  error larger than the structure being initialized.
+
+  The NumPy implementation decomposes the centred matrix directly and agrees with a `longdouble`
+  reference to ~1e-15. Data offset far from the origin is not exotic — timestamps, easting/northing
+  coordinates and absolute sensor readings all look like it.
+
+  **This changes results.** For data near the origin the difference is floating-point noise (~1e-15,
+  and `auto_dimensions` is unaffected because it standardizes first). Far from the origin it is
+  large, and 0.4.0 is the correct one.
+
 ### Changed
 
 - The package is now a pure functional core with a thin shell around it. `python_som._core` holds
@@ -16,14 +53,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   trained weights are bit-identical to 0.3.0 for every combination of training mode and neighborhood
   function, which is asserted rather than assumed.
 
-  The boundary is machine-checked, not merely documented: ruff's `TID251` bans pandas and scikit-learn
+  The boundary is machine-checked, not merely documented: ruff's `TID251` bans pandas and
+  scikit-learn
   outside the two shell modules that exist to adapt them, and reports the reason at the point of
   violation. `architecture-profile.toml` records the style.
 
 - The two update rules are now pure functions returning new arrays. An earlier note claimed this was
-  also faster; **it is not**, and the claim is withdrawn. Measured with interleaved arms and medians,
+  also faster; **it is not**, and the claim is withdrawn. Measured with interleaved arms and
+  medians,
   the pure form is about 10% slower on small maps and indistinguishable above roughly 100x100. The
-  cost buys functions testable without constructing a network, and is single-digit milliseconds over a
+  cost buys functions testable without constructing a network, and is single-digit milliseconds over
+  a
   10,000-iteration run on a 20x20 map. `benchmarks/bench_update.py` is the corrected measurement.
 
 ### Fixed
@@ -112,13 +152,15 @@ Modernizes the packaging and corrects four methodology defects. **Numerical resu
 ### Performance
 
 - Batch training is about 30x faster. The nested Python loop over every pair of nodes is
-  replaced by a NumPy contraction. Measured on a 20x20 map with 150 samples over 5 iterations: 1.89 s
+  replaced by a NumPy contraction. Measured on a 20x20 map with 150 samples over 5 iterations: 1.89
+  s
   to 0.06 s. A regression test asserts the new result matches the old formulation to 1e-12.
 
 ### Internal
 
 - The package moves to a `src/` layout and splits into `_som`, `_neighborhood`, `_decay` and
-  `_distance`. `import python_som; python_som.SOM(...)` is unchanged, and the pre-0.3.0 private names
+  `_distance`. `import python_som; python_som.SOM(...)` is unchanged, and the pre-0.3.0 private
+  names
   (`_asymptotic_decay`, `_euclidean_distance`, and the rest) still resolve.
 - `test_iris.ipynb` is removed; its narrative moved into the documentation. `SOM_atualizado.py`, an
   untracked experimental variant that the sdist had been sweeping up, is gone.
@@ -128,7 +170,8 @@ Modernizes the packaging and corrects four methodology defects. **Numerical resu
 
 - The `bubble` neighborhood is documented as using the Chebyshev metric, so its region is a
   square rather than a disc. The behavior is unchanged and follows Vrieze's appendix pseudo-code
-  (`b = MAX(ABS(i - w_i), ABS(j - w_j))`), but it was previously unstated, and it means the bubble is
+  (`b = MAX(ABS(i - w_i), ABS(j - w_j))`), but it was previously unstated, and it means the bubble
+  is
   *not* isotropic under the Euclidean metric. The test suite shipped in 0.2.0 asserted that it was;
   that assertion passed only because no counterexample exists on a grid that small. The smallest is
   at radius `sqrt(50)`, where `(5, 5)` is inside a `sigma = 5` square and `(7, 1)` is outside.
@@ -169,7 +212,8 @@ Modernizes the packaging and corrects four methodology defects. **Numerical resu
   `_gaussian` and `_mexicanhat` now reject a non-finite or non-positive radius; `_bubble` still
   accepts a radius of zero, which selects the winner alone.
 
-- An unknown `neighborhood_function` raised a bare `KeyError`. It now raises `ValueError` listing the
+- An unknown `neighborhood_function` raised a bare `KeyError`. It now raises `ValueError` listing
+  the
   valid names, matching the behavior of `weight_initialization`.
 
 ### Changed

--- a/architecture-profile.toml
+++ b/architecture-profile.toml
@@ -32,13 +32,15 @@ preset = "functional-core+ports"
 # loosened until it checked nothing.
 core_packages = ["python_som._core"]
 
-# NumPy is the core's one intended dependency. sklearn is here for `_core/_linalg.py` alone, and
-# PR #8 replaces it with `np.linalg.svd`, at which point this becomes `["numpy"]`. scipy is
-# deliberately absent from the preset default: it arrives transitively through sklearn but nothing
-# here imports it, and an allowlist should list what is used.
-core_allowed_third_party = ["numpy", "sklearn"]
+# NumPy, and nothing else. 0.4.0 replaced the one sklearn use (`_core/_linalg.py`) with
+# `np.linalg.svd`, so the allowlist is now as short as it can be without being empty. scipy is
+# deliberately absent from the preset default: it used to arrive transitively through sklearn, and
+# now does not arrive at all.
+core_allowed_third_party = ["numpy"]
 
 source_roots = ["", "src"]
 
-# The pandas boundary. Informational to the checker; the boundary itself is the dependency rule.
+# The data-input boundary. Informational to the checker; the boundary itself is the dependency rule.
+# It no longer adapts pandas specifically -- it is `np.asarray` behind a name -- but it remains the
+# one place that decides what counts as a dataset.
 ports_module = "python_som._convert"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,15 @@ classifiers = [
     "Operating System :: OS Independent",
     "Typing :: Typed",
 ]
+# NumPy is the only thing this package needs at runtime. pandas and scikit-learn were dropped in
+# 0.4.0: pandas because `np.asarray` already converts a DataFrame through the `__array__` protocol,
+# and scikit-learn because its PCA and StandardScaler are twenty lines of `np.linalg.svd`. Together
+# together they pulled in 8 further packages to reach that. Measured on Linux/CPython 3.12, the
+# installed footprint drops from 333 MB across 10 packages to 69 MB across 1: a 264 MB reduction,
+# 79% of the payload. Both remain in
+# `dev`, where the differential tests re-check the replacements against them on every CI run.
 dependencies = [
     "numpy>=1.24",
-    "pandas>=2.0",
-    "scikit-learn>=1.3",
 ]
 
 [project.optional-dependencies]
@@ -37,6 +42,16 @@ cli = ["tqdm>=4.66"]
 dev = [
     "hypothesis==6.163.0",
     "mypy==2.3.0",
+    # Not runtime dependencies. The suite exercises the DataFrame path through the port, and
+    # tests/test_linalg_matches_sklearn.py re-derives every PCA both ways and compares. Pinned like
+    # the rest of the tooling: scikit-learn changed its default PCA solver in 1.5, and a floating pin
+    # would surface that as an unrelated PR's CI failure instead of a Dependabot diff to read.
+    # Split by Python version because the current majors dropped 3.10, which this package still
+    # supports: same reason as tomli below, same pattern.
+    "pandas==3.0.5; python_version >= '3.11'",
+    "pandas==2.3.3; python_version < '3.11'",
+    "scikit-learn==1.9.0; python_version >= '3.11'",
+    "scikit-learn==1.7.2; python_version < '3.11'",
     # pandas-stubs 3.x needs Python >=3.11; it is dev-only, so gate it rather than
     # raising the library's own floor. mypy runs on 3.12 in CI, where it is present.
     "pandas-stubs==3.0.3.260530; python_version >= '3.11'",
@@ -53,8 +68,11 @@ docs = [
     "mkdocs-material==9.7.7",
     "mkdocstrings-python==2.0.5",
 ]
+# Restores the install set that 0.3.0 pulled in by default, for anyone who was relying on it.
 examples = [
     "matplotlib>=3.8",
+    "pandas>=2.0",
+    "scikit-learn>=1.3",
     "seaborn>=0.13",
 ]
 
@@ -105,9 +123,6 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# The two shell modules that adapt a third-party library are exactly where these imports belong.
-"src/python_som/_convert.py" = ["TID251"]          # the pandas port
-"src/python_som/_core/_linalg.py" = ["TID251"]     # sklearn, until PR #8 replaces it with numpy
 # Tests must be able to build a DataFrame to exercise the port, and to compare our PCA against
 # sklearn's differentially. The ban protects the core, not the suite that checks it.
 "tests/*" = [
@@ -128,8 +143,9 @@ ignore = [
 "benchmarks/*" = ["INP001", "T201"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
-# The functional core is numpy-only. These are re-permitted per-file below for the shell modules
-# that exist precisely to adapt them; PR #8 removes both exemptions.
+# The package is numpy-only at runtime, and as of 0.4.0 this ban has no per-file exemption anywhere
+# under src/: the two modules that used to need one no longer import either library. Only tests are
+# exempt, so the replacements can be compared against the originals.
 "pandas".msg = "The core is numpy-only. Convert at the boundary in python_som/_convert.py."
 "sklearn".msg = "The core is numpy-only. Linear algebra belongs in python_som/_core/_linalg.py."
 

--- a/src/python_som/_convert.py
+++ b/src/python_som/_convert.py
@@ -1,12 +1,19 @@
 """The data-input port: whatever the caller passed, in, an ``ndarray`` out.
 
-This is the only module in the package that knows pandas exists, which is what lets ruff's
-``TID251`` ban pandas everywhere else. Everything downstream of here works on ``np.ndarray`` only.
+Through 0.3.0 this module special-cased pandas, testing ``isinstance(data, pd.DataFrame |
+pd.Series)`` before calling ``.to_numpy()``. That was the only use of pandas, and it was redundant:
+``np.asarray`` already converts both through the ``__array__`` protocol, with identical results
+including for nullable extension dtypes, which convert to ``float64`` with ``nan`` either way.
 
-The pandas branch is strictly redundant. ``np.asarray`` already converts a DataFrame or a Series
-through the ``__array__`` protocol, with results identical to ``.to_numpy()`` including for nullable
-extension dtypes. It is kept so that removing the pandas dependency is its own reviewable change
-rather than a side effect of the module split.
+Dropping the special case removes a required dependency and **widens** what the package
+accepts, because ``__array__`` is a protocol rather than a library. polars, pyarrow, xarray and CuPy
+objects all implement it and now work without python-som knowing any of them exist. Fewer
+dependencies and more capability at once, which is the argument for a port rather than an adapter
+per library.
+
+The module stays, small as it is, because it is the one place that decides what "a dataset" means.
+When that decision needs to change -- a dtype policy, a shape check, an explicit error for ragged
+input -- there is one place to change it, and the core keeps receiving ``ndarray`` and nothing else.
 """
 
 from __future__ import annotations
@@ -14,25 +21,27 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import numpy.typing as npt
-import pandas as pd
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import TypeAlias
 
-    #: Anything the public methods accept as a dataset. Anything implementing ``__array__`` works in
-    #: practice, including polars, pyarrow and xarray objects; these are the types we promise.
-    DataLike: TypeAlias = npt.NDArray[Any] | pd.DataFrame | pd.Series[Any] | list[Any]
+    import numpy.typing as npt
+
+    #: Anything the public methods accept as a dataset. Named rather than inlined so the promise has
+    #: somewhere to live: anything implementing ``__array__`` works, which covers pandas, polars,
+    #: pyarrow and xarray without importing any of them.
+    DataLike: TypeAlias = npt.ArrayLike
 
 __all__ = ["to_numpy"]
 
 
 def to_numpy(data: DataLike) -> npt.NDArray[Any]:
-    """Convert a DataFrame, Series, list or array to a NumPy array.
+    """Convert anything array-like to a NumPy array.
+
+    Handles DataFrames, Series, lists, and any object implementing ``__array__``. Existing arrays
+    pass through without a copy.
 
     :param data: Input data.
     :return: The data as a NumPy array.
     """
-    if isinstance(data, pd.DataFrame | pd.Series):
-        return data.to_numpy()
     return np.asarray(data)

--- a/src/python_som/_core/_linalg.py
+++ b/src/python_som/_core/_linalg.py
@@ -1,12 +1,24 @@
-"""Principal component analysis, and the map sizing that depends on it."""
+"""Principal component analysis, and the map sizing that depends on it.
+
+Implemented on ``np.linalg.svd`` rather than scikit-learn. PCA and a z-score were the only two
+things this package used scikit-learn for, and carrying it as a required dependency pulled in scipy,
+joblib and threadpoolctl to reach about twenty lines of linear algebra.
+
+The two functions here reproduce ``sklearn.decomposition.PCA(n_components=k)`` and
+``sklearn.preprocessing.StandardScaler().fit_transform`` exactly, sign conventions and
+degenerate-column handling included. "Exactly" is not an assertion of faith:
+``tests/test_linalg_matches_sklearn.py`` re-checks it against the real scikit-learn on every CI run,
+which is why scikit-learn remains a *test* dependency. Two details are easy to get wrong and are
+therefore spelled out where they are implemented: the sign convention is v-based, not the more
+common u-based one, and a near-constant column is scaled by 1 rather than by its own vanishing
+standard deviation.
+"""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
-import sklearn.decomposition
-import sklearn.preprocessing
 
 if TYPE_CHECKING:  # pragma: no cover
     import numpy.typing as npt
@@ -33,27 +45,70 @@ class PrincipalComponents(NamedTuple):
 def pca(data: npt.NDArray[Any], n_components: int = _N_COMPONENTS) -> PrincipalComponents:
     """Fit a PCA and return its mean, components and explained variance.
 
+    The singular value decomposition of the centred data gives the components directly: for
+    ``X - mean = U S V^T``, the rows of ``V^T`` are the component directions and ``S^2 / (n - 1)``
+    the variance along each.
+
+    **On the sign convention.** An SVD determines each component only up to sign, so a convention is
+    needed for the result to be reproducible. scikit-learn's PCA calls ``svd_flip`` with
+    ``u_based_decision=False``, which orients each component so that its largest-magnitude *loading*
+    is positive. That is the less common of the two conventions in that helper, and taking its
+    default instead would flip the sign of some components: the fit would still be a valid PCA, but
+    it would not be the same one, and linear initialization would lay its models out reversed along
+    that axis.
+
     :param data: Array of shape ``(n_samples, n_features)``.
     :param n_components: Number of components to keep.
     :return: The fitted mean, components and explained variance.
     """
-    fitted = sklearn.decomposition.PCA(n_components=n_components, random_state=0)
-    fitted.fit(data)
+    array = np.asarray(data, dtype=float)
+    mean = array.mean(axis=0)
+    _, singular_values, right_vectors = np.linalg.svd(array - mean, full_matrices=False)
+
+    # Orient each component on its largest-magnitude loading. The flip is applied to all of them
+    # before truncation, which is the order scikit-learn does it in.
+    dominant = np.argmax(np.abs(right_vectors), axis=1)
+    signs = np.sign(right_vectors[np.arange(right_vectors.shape[0]), dominant])
+    right_vectors = right_vectors * signs[:, None]
+
+    explained_variance = singular_values**2 / (array.shape[0] - 1)
     return PrincipalComponents(
-        mean=fitted.mean_,
-        components=fitted.components_,
-        explained_variance=fitted.explained_variance_,
+        mean=mean,
+        components=right_vectors[:n_components],
+        explained_variance=explained_variance[:n_components],
     )
 
 
 def standardize(data: npt.NDArray[Any]) -> npt.NDArray[np.floating]:
     """Centre each column on zero and scale it to unit variance.
 
+    The variance is the population variance (``ddof=0``), which is what ``StandardScaler`` uses.
+
+    **On constant columns.** A column with no variance would be divided by zero, giving ``inf`` or
+    ``nan`` and poisoning the PCA downstream. Such a column is scaled by 1 instead, leaving it at
+    its centred value of zero. The test for it is not ``variance == 0`` but scikit-learn's bound
+    from Chan, Golub and LeVeque on the error of the two-pass variance algorithm, so that a column
+    which is constant in exact arithmetic is still caught when floating-point noise leaves it merely
+    very small.
+
     :param data: Array of shape ``(n_samples, n_features)``.
     :return: The standardized array.
     """
-    scaled: npt.NDArray[np.floating] = sklearn.preprocessing.StandardScaler().fit_transform(data)
-    return scaled
+    array = np.asarray(data, dtype=float)
+    mean = array.mean(axis=0)
+    variance = array.var(axis=0)
+
+    n_samples = array.shape[0]
+    eps = np.finfo(np.float64).eps
+    indistinguishable_from_constant = variance <= (
+        n_samples * eps * variance + (n_samples * mean * eps) ** 2
+    )
+
+    scale = np.sqrt(variance)
+    scale[indistinguishable_from_constant] = 1.0
+
+    standardized: npt.NDArray[np.floating] = (array - mean) / scale
+    return standardized
 
 
 def auto_dimensions(x: int | None, y: int | None, data: npt.NDArray[Any]) -> tuple[int, int]:

--- a/tests/test_core_boundary.py
+++ b/tests/test_core_boundary.py
@@ -62,13 +62,31 @@ def test_no_core_module_imports_pandas() -> None:
     assert not offenders, f"the core must not import pandas: {offenders}"
 
 
-def test_sklearn_appears_in_exactly_one_core_module() -> None:
-    """``_linalg`` is the only place sklearn is reached, and PR #8 replaces it with numpy.
+def test_no_core_module_imports_sklearn() -> None:
+    """0.4.0 replaced the one sklearn use with ``np.linalg.svd``, so the ban is now absolute.
 
-    Pinning it to one module is what makes that removal a single-file change rather than a hunt.
+    Through 0.3.0 this asserted the opposite -- that ``_linalg`` was the *only* module reaching
+    sklearn -- which is what kept the removal a single-file change rather than a hunt.
     """
-    users = sorted(p.name for p in _CORE.glob("*.py") if "sklearn" in _imports_of(p))
-    assert users == ["_linalg.py"], users
+    offenders = sorted(p.name for p in _CORE.glob("*.py") if "sklearn" in _imports_of(p))
+    assert not offenders, f"the core must not import scikit-learn: {offenders}"
+
+
+def test_the_whole_package_is_numpy_only_at_runtime() -> None:
+    """The shell, not just the core. This is what the 264 MB saving actually rests on.
+
+    Scans every module under ``src/`` rather than only ``_core/``, because after 0.4.0 no module in
+    the package imports pandas or scikit-learn -- the port is ``np.asarray`` and the PCA is
+    ``np.linalg.svd``. A `per-file-ignores` entry restoring either would pass ruff silently.
+    """
+    package = pathlib.Path(python_som.__file__).parent
+    banned = {"pandas", "sklearn", "scipy"}
+    offenders = {
+        str(path.relative_to(package)): sorted(_imports_of(path) & banned)
+        for path in package.rglob("*.py")
+        if _imports_of(path) & banned
+    }
+    assert not offenders, f"runtime modules must not import {banned}: {offenders}"
 
 
 def test_every_core_module_is_importable() -> None:

--- a/tests/test_linalg_matches_sklearn.py
+++ b/tests/test_linalg_matches_sklearn.py
@@ -1,0 +1,218 @@
+"""Check the NumPy PCA and z-score against the scikit-learn implementations they replaced.
+
+0.4.0 dropped scikit-learn as a runtime dependency and reimplemented the two things this package
+used it for on ``np.linalg.svd``. That trades 264 MB of required install for about twenty lines of
+linear algebra, and it is the one change in the release a reviewer should be least willing to take
+on trust.
+
+So it is not taken on trust. scikit-learn stays in the ``dev`` extra purely so this file can run,
+and every CI run re-derives the same fits both ways and compares them. The claim under test is not
+"close enough" but "the same numbers": tolerances here are at the scale of double-precision
+round-off, not at the scale of a plausible-looking answer.
+
+The module is skipped rather than failed where scikit-learn is absent, so that the package's own
+test suite still runs in an environment that installed only the runtime dependency.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from python_som._core._linalg import pca, standardize
+
+sklearn_decomposition = pytest.importorskip("sklearn.decomposition")
+sklearn_preprocessing = pytest.importorskip("sklearn.preprocessing")
+
+#: Round-off scale for a double-precision SVD. Agreement is expected at about 1e-15; this leaves
+#: room for the conditioning of the harder shapes without admitting a genuinely different answer.
+TOLERANCE = 1e-10
+
+#: Shapes worth covering, including the awkward ones. ``(6, 12)`` has fewer samples than features,
+#: which is where a naive covariance-matrix implementation would disagree; ``(200, 2)`` is exactly
+#: as many components as are asked for.
+SHAPES = [(50, 5), (200, 2), (6, 12), (30, 8), (1000, 4)]
+
+#: Independent of the fixture seeds: this file compares two implementations, not two runs.
+SEED = 20260730
+
+
+def _matrix(shape: tuple[int, int], *, scale: float = 1.0, offset: float = 0.0) -> np.ndarray:
+    """Build a reproducible random matrix.
+
+    :param shape: Shape of the matrix.
+    :param scale: Multiplier applied to every entry, to vary conditioning.
+    :param offset: Constant added to every entry, to move it away from the origin.
+    :return: The matrix.
+    """
+    rng = np.random.default_rng(SEED + shape[0] * 100 + shape[1])
+    return rng.normal(size=shape) * scale + offset
+
+
+@pytest.mark.parametrize("shape", SHAPES)
+def test_pca_matches_sklearn(shape: tuple[int, int]) -> None:
+    """Mean, components and explained variance all agree, signs included."""
+    data = _matrix(shape)
+    n_components = min(2, *shape)
+
+    theirs = sklearn_decomposition.PCA(n_components=n_components, random_state=0).fit(data)
+    ours = pca(data, n_components=n_components)
+
+    np.testing.assert_allclose(ours.mean, theirs.mean_, atol=TOLERANCE)
+    np.testing.assert_allclose(ours.explained_variance, theirs.explained_variance_, atol=TOLERANCE)
+    # Not abs(): the sign convention is the part most likely to be wrong, so it is what is asserted.
+    np.testing.assert_allclose(ours.components, theirs.components_, atol=TOLERANCE)
+
+
+@pytest.mark.parametrize(("scale", "offset"), [(1e-6, 0.0), (1e6, 0.0), (1.0, 1e5), (1e-3, -50.0)])
+def test_pca_matches_sklearn_away_from_unit_scale(scale: float, offset: float) -> None:
+    """Badly scaled and far-from-origin data, against scikit-learn's *exact* solver.
+
+    Deliberately ``svd_solver="full"`` rather than the default ``"auto"``, and the reason is worth
+    recording because the first version of this test failed and the reference was what was wrong.
+
+    Since 1.5, ``"auto"`` selects ``covariance_eigh`` when samples comfortably outnumber features,
+    which forms the covariance matrix and eigendecomposes it. Squaring the data squares its
+    condition number, so on data centred far from the origin that path loses precision. Measured on
+    ``(80, 6)`` offset by 1e5, against a reference centred in ``longdouble`` before decomposing:
+
+    ==========================  ====================
+    solver                      relative error
+    ==========================  ====================
+    sklearn ``auto``            1.4e-06 to 5.5e-06
+    sklearn ``full``            ~1e-15
+    this implementation         ~1e-15
+    ==========================  ====================
+
+    So the SVD of the centred matrix is the more accurate of the two, and comparing against
+    ``"auto"`` would fail a correct implementation for agreeing with the mathematics rather than
+    with scikit-learn's default. ``"full"`` is the same algorithm this package uses and is what the
+    comparison is worth making against.
+    """
+    data = _matrix((80, 6), scale=scale, offset=offset)
+
+    theirs = sklearn_decomposition.PCA(n_components=2, random_state=0, svd_solver="full").fit(data)
+    ours = pca(data)
+
+    np.testing.assert_allclose(ours.mean, theirs.mean_, rtol=1e-9)
+    np.testing.assert_allclose(ours.explained_variance, theirs.explained_variance_, rtol=1e-9)
+    np.testing.assert_allclose(ours.components, theirs.components_, atol=1e-9)
+
+
+@pytest.mark.parametrize("offset", [0.0, 1e5, -1e6])
+def test_pca_is_accurate_against_a_higher_precision_reference(offset: float) -> None:
+    """Agreement with scikit-learn is evidence; agreement with the mathematics is the claim.
+
+    Centring in ``longdouble`` before decomposing removes the cancellation that far-from-origin
+    data causes, giving a reference that does not depend on any library's solver choice. This is
+    the assertion that would survive scikit-learn changing its defaults again.
+    """
+    data = _matrix((80, 6), offset=offset)
+
+    exact = data.astype(np.longdouble)
+    centred = (exact - exact.mean(axis=0)).astype(np.float64)
+    truth = np.linalg.svd(centred, compute_uv=False)[:2] ** 2 / (data.shape[0] - 1)
+
+    np.testing.assert_allclose(pca(data).explained_variance, truth, rtol=1e-12)
+
+
+def test_pca_sign_convention_is_v_based_not_u_based() -> None:
+    """Pin the convention itself, not just agreement on one dataset.
+
+    scikit-learn's ``svd_flip`` defaults to ``u_based_decision=True``, but its PCA passes ``False``.
+    Taking the default would still produce a valid PCA, so no test of orthonormality or explained
+    variance would notice; only comparing the signs does. This asserts the resulting property
+    directly: each component's largest-magnitude entry is positive.
+    """
+    for shape in [(50, 5), (30, 8), (6, 12)]:
+        components = pca(_matrix(shape)).components
+        dominant = np.abs(components).argmax(axis=1)
+        leading = components[np.arange(components.shape[0]), dominant]
+        assert (leading > 0).all(), f"{shape}: expected positive dominant loadings, got {leading}"
+
+
+@pytest.mark.parametrize("shape", SHAPES)
+def test_standardize_matches_standard_scaler(shape: tuple[int, int]) -> None:
+    """The z-score agrees column for column."""
+    data = _matrix(shape)
+    theirs = sklearn_preprocessing.StandardScaler().fit_transform(data)
+    np.testing.assert_allclose(standardize(data), theirs, atol=TOLERANCE)
+
+
+def test_standardize_matches_standard_scaler_on_a_constant_column() -> None:
+    """A column with no variance must not become ``inf`` or ``nan``.
+
+    Dividing by its standard deviation of zero is the obvious implementation and the wrong one.
+    scikit-learn scales such a column by 1, leaving it centred at zero, and so does this.
+    """
+    data = _matrix((40, 4))
+    data[:, 2] = 7.0
+
+    ours = standardize(data)
+    theirs = sklearn_preprocessing.StandardScaler().fit_transform(data)
+
+    assert np.isfinite(ours).all(), "a constant column produced a non-finite value"
+    np.testing.assert_allclose(ours[:, 2], 0.0, atol=TOLERANCE)
+    np.testing.assert_allclose(ours, theirs, atol=TOLERANCE)
+
+
+def test_standardize_matches_standard_scaler_on_a_near_constant_column() -> None:
+    """Constant in exact arithmetic, merely tiny in floating point.
+
+    This is why the guard is scikit-learn's Chan-Golub-LeVeque bound rather than ``variance == 0``:
+    a column built by arithmetic that should cancel exactly can retain a variance of about 1e-30,
+    which passes an equality test and then divides the column by roughly 1e-15.
+    """
+    data = _matrix((40, 3))
+    data[:, 1] = np.full(40, 1e8) + np.linspace(0, 1e-9, 40)
+
+    ours = standardize(data)
+    theirs = sklearn_preprocessing.StandardScaler().fit_transform(data)
+
+    assert np.isfinite(ours).all()
+    np.testing.assert_allclose(ours, theirs, atol=TOLERANCE)
+
+
+def test_linear_initialization_is_accurate_far_from_the_origin() -> None:
+    """Regression for a real defect in 0.3.0, not merely a precision preference.
+
+    Linear initialization fits PCA on **raw** data on purpose, so the models share the space of the
+    inputs they are compared against. Through 0.3.0 that PCA went to scikit-learn's ``auto`` solver,
+    which for these shapes is ``covariance_eigh``: it forms the covariance matrix, and when the mean
+    is large relative to the spread, squaring the data destroys the information the spread lives in.
+
+    On ``(150, 4)`` data offset by 1e7, 0.3.0's second explained variance was wrong by **5.8%**, and
+    the resulting models differed from the correct ones by 2.43 against a total model spread of 2.0
+    -- an error larger than the structure being initialized. Data offset far from the origin is not
+    exotic: timestamps, easting/northing coordinates and absolute sensor readings all look like it.
+
+    The reference is computed in ``longdouble`` so it depends on no library's solver choice.
+    """
+    rng = np.random.default_rng(3)
+    data = rng.normal(size=(150, 4)) + 1e7
+
+    exact = data.astype(np.longdouble)
+    centred = (exact - exact.mean(axis=0)).astype(np.float64)
+    truth = np.linalg.svd(centred, compute_uv=False)[:2] ** 2 / (data.shape[0] - 1)
+
+    np.testing.assert_allclose(pca(data).explained_variance, truth, rtol=1e-12)
+
+    # Show the defect this protects against, when the installed scikit-learn still exhibits it.
+    # Conditioned on the solver rather than assumed: `covariance_eigh` arrived in 1.5, the CI matrix
+    # runs an older pin on Python 3.10, and a future release could pick differently again. The
+    # assertion above is the claim; this is the illustration, and it must not fail for being stale.
+    legacy = sklearn_decomposition.PCA(n_components=2, random_state=0).fit(data)
+    if getattr(legacy, "_fit_svd_solver", None) == "covariance_eigh":
+        error = (np.abs(legacy.explained_variance_ - truth) / truth).max()
+        assert error > 1e-3, f"expected the covariance path to be inaccurate here, got {error:.2e}"
+
+
+def test_the_numpy_implementation_is_the_one_the_package_uses() -> None:
+    """Guard against the differential test quietly becoming the reason the dependency stays.
+
+    The corresponding negative — that no module in the core imports scikit-learn at all — is
+    asserted by ``tests/test_core_boundary.py``, which scans imports rather than behaviour.
+    """
+    som_pca = pca(_matrix((40, 4)))
+    assert isinstance(som_pca.components, np.ndarray)
+    assert som_pca.components.shape == (2, 4)

--- a/uv.lock
+++ b/uv.lock
@@ -2269,10 +2269,6 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.optional-dependencies]
@@ -2282,11 +2278,15 @@ cli = [
 dev = [
     { name = "hypothesis" },
     { name = "mypy" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas-stubs", marker = "python_full_version >= '3.11'" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "twine" },
     { name = "types-tqdm" },
@@ -2298,6 +2298,10 @@ docs = [
 examples = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "seaborn" },
 ]
 
@@ -2309,13 +2313,17 @@ requires-dist = [
     { name = "mkdocstrings-python", marker = "extra == 'docs'", specifier = "==2.0.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "numpy", specifier = ">=1.24" },
-    { name = "pandas", specifier = ">=2.0" },
+    { name = "pandas", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = "==3.0.5" },
+    { name = "pandas", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = "==2.3.3" },
+    { name = "pandas", marker = "extra == 'examples'", specifier = ">=2.0" },
     { name = "pandas-stubs", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = "==3.0.3.260530" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.6.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.0" },
-    { name = "scikit-learn", specifier = ">=1.3" },
+    { name = "scikit-learn", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = "==1.9.0" },
+    { name = "scikit-learn", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = "==1.7.2" },
+    { name = "scikit-learn", marker = "extra == 'examples'", specifier = ">=1.3" },
     { name = "seaborn", marker = "extra == 'examples'", specifier = ">=0.13" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = "==2.4.1" },
     { name = "tqdm", marker = "extra == 'cli'", specifier = ">=4.66" },


### PR DESCRIPTION
`numpy` becomes the only runtime dependency. Second of five PRs for 0.4.0, on top of #7.

## Measured, not estimated

| | 0.3.0 | 0.4.0 |
| --- | --- | --- |
| packages installed | **10** | **1** |
| site-packages payload | **333 MB** | **69 MB** |

A 264 MB reduction, 79% of the payload, on Linux/CPython 3.12 in a clean venv. The plan estimated
"178 MB → 34 MB" from per-package figures; both numbers were wrong, because the transitive set
(scipy, joblib, narwhals, python-dateutil, six, threadpoolctl) is bigger than the two named packages.
Every citation of the estimate in the tree has been replaced with the measurement.

## pandas → `np.asarray`

The entire use was `isinstance(data, pd.DataFrame | pd.Series)` before calling `.to_numpy()`.
`np.asarray` already does exactly that through the `__array__` protocol, identically, including for
nullable extension dtypes (both give `float64` with `nan`).

Because `__array__` is a *protocol* rather than a library, removing the special case **widens** what
the package accepts: polars, pyarrow, xarray and CuPy objects now work, with python-som importing
none of them. Fewer dependencies and more capability from the same change.

## scikit-learn → `np.linalg.svd`

`PCA(n_components=2)` and `StandardScaler` become about twenty lines in `_core/_linalg.py`. Two
details were read out of the installed scikit-learn rather than recalled, because either would fail
silently:

- **The sign convention is v-based.** PCA calls `svd_flip(U, Vt, u_based_decision=False)` — not that
  helper's default. Taking the default would still produce a valid PCA, so no test of orthonormality
  or explained variance would notice; only the signs differ, and linear initialization would lay its
  models out reversed along that axis.
- **A near-constant column is scaled by 1**, detected with scikit-learn's Chan–Golub–LeVeque bound
  rather than `variance == 0`. A column that should cancel exactly can retain a variance around 1e-30,
  which passes an equality test and then divides the column by roughly 1e-15.

Both libraries stay in `dev`, and `tests/test_linalg_matches_sklearn.py` re-derives every fit both
ways on every CI run. That is what makes a reimplemented PCA reviewable instead of a matter of trust.

## Writing that test found a real bug in 0.3.0

Linear initialization fits PCA on **raw** data on purpose, so models share the space of the inputs
they are compared against. Through 0.3.0 that went to scikit-learn's `auto` solver, which since 1.5
selects `covariance_eigh` when samples outnumber features. Forming the covariance matrix squares the
condition number, so when the mean is large relative to the spread, the spread is what gets lost.

On `(150, 4)` data offset by 1e7, against a `longdouble` reference:

| | second explained variance | relative error |
| --- | --- | --- |
| 0.3.0 (`auto` → `covariance_eigh`) | 1.11501159 | **5.8%** |
| 0.4.0 (this PR) | 1.05415649 | 6e-16 |

The initialized models differed by **2.43 against a total model spread of 2.0** — an error larger than
the structure being initialized. Data offset far from the origin is not exotic: timestamps,
easting/northing coordinates and absolute sensor readings all look like it.

**Results change.** Near the origin the difference is floating-point noise (~1e-15; `auto_dimensions`
is unaffected because it standardizes first). Far from the origin it is large, and 0.4.0 is correct.

### The first version of this test failed, and the reference was what was wrong

It compared against `PCA(...)` with default `auto`, and my implementation "disagreed" at 4e-07. The
disagreement was scikit-learn's. Against a `longdouble` reference, `auto` had ~1e-06 relative error
where both `svd_solver="full"` and this implementation had ~1e-15. So the comparison is now against
`"full"` — the same algorithm — plus an independent assertion against the higher-precision reference,
which survives scikit-learn changing its defaults again. The illustration that the old path was
inaccurate is conditioned on the installed solver actually being `covariance_eigh`, so it cannot fail
for being stale on the Python 3.10 matrix entry.

## The boundary is now absolute

No module under `src/` imports either library, so both `TID251` per-file exemptions are deleted and
the ban has no exemption outside `tests/`. `core_allowed_third_party` tightens to `["numpy"]`.

`tests/test_core_boundary.py` gains a scan of the **whole package** rather than only `_core/`, because
that is what the 264 MB rests on and a `per-file-ignores` entry added later would silence ruff without
failing anything. The old assertion that `_linalg` was the *only* sklearn user inverts to: nothing
imports it.

## Verification

- 237 tests, **100% coverage**, ruff / `ruff format` / `mypy --strict` clean, `mkdocs build --strict`
  clean, `twine check` passes.
- The built wheel installed in a clean venv with **numpy alone** trains end to end, and `pandas` and
  `sklearn` are absent from `sys.modules`.
- **No new package is introduced**: the full all-extras dependency closure is unchanged before and
  after, and the runtime closure is `numpy`. pandas and scikit-learn were already 0.3.0 dependencies;
  they only moved out of the default group.
- `dependency-check` reports nothing real. It flags the four marker-gated pins as "not pinned"
  because its parser tests for `==` without stripping the `;` marker — all four are exact pins, which
  the repo's own packaging test confirms by stripping it. The `examples` lower bounds match that
  extra's existing convention (`matplotlib>=3.8`, `seaborn>=0.13` predate this PR).

## Note on the Python 3.10 matrix entry

pandas 3.x and scikit-learn 1.9 both require ≥3.11, and this package still supports 3.10, so the dev
pins are split by `python_version` — the same pattern already used for `tomli`/`tomllib` and
`pandas-stubs`. That keeps the DataFrame path and the differential PCA tests running on every matrix
entry instead of skipping them on the oldest one.
