### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-07-30
+
+`numpy` is now the only runtime dependency, and a trained map can be saved without `pickle`.
+
+**Results change in two places.** Linear initialization is corrected for data far from the origin,
+where 0.3.0 was wrong by up to 5.8%; and anyone who imported pandas or scikit-learn transitively
+through this package must now depend on them directly. Everything else is additive: no public name or
+signature is removed, and `mode="batch"` and the other plain strings keep working.
+
+To reproduce a figure made with an earlier version, pin that version.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "python-som"
-version = "0.3.0"
+version = "0.4.0"
 authors = [{ name = "André Moreira Souza", email = "msouza.andre@hotmail.com" }]
 description = "Python implementation of the Self-Organizing Map"
 readme = "README.md"

--- a/src/python_som/_version.py
+++ b/src/python_som/_version.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2559,7 +2559,7 @@ wheels = [
 
 [[package]]
 name = "python-som"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Version bump and changelog for **0.4.0**. Merging this, then tagging `v0.4.0`, triggers the trusted
publisher.

## What 0.4.0 is

`numpy` is the only runtime dependency, and a trained map can be saved without `pickle`.

| | 0.3.0 | 0.4.0 |
| --- | --- | --- |
| runtime packages installed | 10 (333 MB) | **1 (69 MB)** |
| batch training | baseline | **1.2x–1.5x faster** |
| saving a map | `pickle`, or nothing | `save_npz` / `load_npz` |
| a typo in `mode=` | `ValueError` at runtime | type error |

## Results change in two places

Stated plainly because this is a research library:

- **Linear initialization is corrected** for data far from the origin. 0.3.0 routed its PCA through
  scikit-learn's `auto` solver, which picks `covariance_eigh` when samples outnumber features and
  loses precision when the mean dominates the spread. On `(150, 4)` data offset by 1e7 the second
  explained variance was wrong by 5.8%. Near the origin the difference is floating-point noise.
- **pandas and scikit-learn are gone as runtime dependencies.** If you imported either transitively
  through this package, depend on them directly. `pip install python-som[examples]` restores the old
  install set.

Everything else is additive. No public name or signature is removed; `mode="batch"` and the other
plain strings keep working and will until 1.0.0.

## Verified from the built wheel, not the source tree

```
installed set:  numpy==2.5.1, python-som==0.4.0
trained:        error 0.7103, report mode=batch
round trip:     bit-identical
pandas/sklearn: never imported
py.typed:       shipped
[cli] extra:    resolves to tqdm==4.70.0
```

Plus the usual gates: 369 tests at 100% coverage, ruff / `ruff format` / `mypy --strict` clean,
`mkdocs build --strict` exits 0, `twine check` passes both artifacts, bandit clean, `pip-audit`
reports no known vulnerabilities, architecture profile `--strict` passes.

## After merge

1. Tag `v0.4.0` immediately, so master never claims an untagged version for long.
2. `release.yml` builds, then waits on the `pypi` environment's required reviewer.
3. **The PyPI upload is irreversible** — a version number can never be reused, even after deletion.
   I will ask for explicit confirmation immediately before approving it, and will not proceed without
   it.
4. The `github-release` job runs after publish, so the tag gets a release with the changelog body.

## Note on the next version

0.4.0 documents the plain-string deprecation but emits no warning, because `mode="batch"` is what the
docs showed until this release. **0.5.0 must ship the `DeprecationWarning` before 1.0.0 can remove
strings** — the policy is that a removal in a major release follows at least one minor release that
warns. Recorded in the plan so 1.0.0 does not skip it.