### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-07-30
+
+One change: the plain-string options now warn. Nothing else moves, and no result changes.
+
+This is the release 1.0.0 was waiting on. The policy is that anything removed in a major release
+warns for at least one minor release first, so strings could not be removed until this shipped.
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "python-som"
-version = "0.4.0"
+version = "0.5.0"
 authors = [{ name = "André Moreira Souza", email = "msouza.andre@hotmail.com" }]
 description = "Python implementation of the Self-Organizing Map"
 readme = "README.md"

--- a/src/python_som/_version.py
+++ b/src/python_som/_version.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2559,7 +2559,7 @@ wheels = [
 
 [[package]]
 name = "python-som"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Version bump and changelog for **0.5.0**. One change, no results move.

## What it is

Plain-string options now emit `DeprecationWarning`:

```
Passing mode='batch' as a plain string is deprecated and will stop working in 1.0.0.
Use TrainingMode.BATCH instead.
```

That is the whole release. Deliberately single-purpose, so the one behaviour change is easy to see
and easy to revert if it turns out to be noisy in practice.

## Why it has to exist

**1.0.0 was blocked on it.** The stated policy is that anything removed in a major release warns for
at least one minor release first. 0.4.0 deprecated strings *in writing only*, because `mode="batch"`
was what every documentation page showed at the time. Without this release, 1.0.0 removing strings
would breach the policy the project set for itself.

## Nothing else moves

No numerical change, no API removal, no dependency change. Anything that worked in 0.4.0 works here
and produces identical output. The only observable difference is the warning, which names the exact
replacement so migrating is a substitution you read off the message.

To silence it while migrating:

```python
import warnings
warnings.filterwarnings("ignore", category=DeprecationWarning, module="python_som")
```

## Verified from the built wheel

```
installed set:   numpy==2.5.1, python-som==0.5.0
enums:           train under -W error::DeprecationWarning, no warning
plain strings:   warn, naming the replacement
```

Plus 384 tests at 100% coverage, ruff / `ruff format` / `mypy --strict` clean, `mkdocs build
--strict` exits 0, `twine check` passes both artifacts.

## After merge

Tag `v0.5.0`, then the workflow builds and waits on the `pypi` environment's required reviewer. **The
upload is irreversible** — I will ask before approving it.