### PR TITLE
release: 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2026-07-30
+
+A map can now be used as a scikit-learn estimator, and the plain-string deprecation from 0.5.0 is
+withdrawn. Nothing breaks and no numerical results change: `train` is untouched, both option spellings
+work, and scikit-learn remains optional.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "python-som"
-version = "0.5.0"
+version = "0.6.0"
 authors = [{ name = "André Moreira Souza", email = "msouza.andre@hotmail.com" }]
 description = "Python implementation of the Self-Organizing Map"
 readme = "README.md"

--- a/src/python_som/_version.py
+++ b/src/python_som/_version.py
@@ -9,4 +9,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2559,7 +2559,7 @@ wheels = [
 
 [[package]]
 name = "python-som"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Version bump and changelog for **0.6.0**. Nothing breaks, no results change.

## What 0.6.0 is

Two things, both additive:

- **A map can be used as a scikit-learn estimator.** `fit`, `transform`, `predict`, `score`,
  `get_params`, `set_params` on `SOM`, plus `python_som.sklearn.SOMEstimator` for full `Pipeline` and
  `GridSearchCV` integration behind `pip install "python-som[sklearn]"`.
- **The plain-string deprecation from 0.5.0 is withdrawn.** Strings are permanent.

`train` is untouched and remains primary. `numpy` is still the only runtime dependency.

## The withdrawal, stated plainly

0.5.0 shipped a `DeprecationWarning` announcing that `mode="batch"` would stop working in 1.0.0. That
was wrong, and this release reverses it. Every comparable library passes options as plain strings and
none export enums — scikit-learn, numpy, scipy, minisom, sompy — so removing the string form would have
made this the only library in its ecosystem to reject `mode="batch"`.

Anyone who migrated to the enums while 0.5.0 was current keeps working code: the enums are staying too.
The changelog says so directly rather than quietly dropping the warning.

## Verified from the built wheel, both ways

```
numpy only:
  version 0.6.0
  estimator methods: predict (40,)  transform (40, 30)  score -0.5236
  plain strings under -W error::DeprecationWarning: silent
  python_som.sklearn: correctly unavailable, with a message naming the extra

with [sklearn]:
  GridSearchCV(SOMEstimator(y=4), {"x": [4, 6]}, cv=3) -> best {'x': 6}, score -1.1440
```

Plus 424 tests at 100% coverage, ruff / `ruff format` / `mypy --strict` clean, `mkdocs build --strict`
exits 0, `twine check` passes both artifacts.

## Where 1.0.0 stands

Deliberately not next. What remains breaking is thin — keyword-only arguments, removing two setters,
removing pre-0.3.0 private aliases, dropping Python 3.10 after its October 2026 EOL — and the estimator
interface introduced here should have real use before the API is frozen around it. `refactor/enums-only`
is dropped from the plan entirely.

## After merge

Tag `v0.6.0`, then the workflow builds and waits on the `pypi` environment reviewer, which you
authorise in the GitHub UI.